### PR TITLE
Only publish index.js to npm

### DIFF
--- a/modules/rollup-plugin-workbox-inject/package.json
+++ b/modules/rollup-plugin-workbox-inject/package.json
@@ -26,5 +26,8 @@
     "chalk": "^3.0.0",
     "fast-json-stable-stringify": "^2.1.0",
     "workbox-build": "^5.0.0-rc.1"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
I noticed that `.nyc_output` and `tests` were showing up in my local `node_modules/rollup-plugin-workbox-inject/` folder, which don't need to be published to `npm`.

As per https://docs.npmjs.com/files/package.json#files, the `README.md` and `package.json` will also be published automatically.