### PR TITLE
General housekeeping for the Workbox Rollup plugin

### DIFF
--- a/modules/rollup-plugin-workbox-inject/README.md
+++ b/modules/rollup-plugin-workbox-inject/README.md
@@ -1,42 +1,59 @@
 # Rollup Plugin Workbox Inject
 
-A [Workbox](https://developers.google.com/web/tools/workbox) plugin for [Rollup](https://rollupjs.org/guide/en/) that allows you to use Rollup to compile your Service Worker and have Workbox [inject a precache into it](https://developers.google.com/web/tools/workbox/guides/precache-files/cli). This differs from other Rollup/Workbox plugins in that Rollup controls the entire compiling/outputting process of the Service Worker instead of Workbox moving the file over and bypassing Rollup.
+A [Workbox](https://developers.google.com/web/tools/workbox) plugin for
+[Rollup](https://rollupjs.org/guide/en/) that allows you to use Rollup to
+compile your service worker and have Workbox
+[inject a precache manifest into it](https://developers.google.com/web/tools/workbox/guides/precache-files/cli).
+This differs from other Rollup/Workbox plugins in that Rollup controls the
+entire compiling/outputting process of the service worker instead of Workbox
+moving the file over and bypassing Rollup.
 
 ## Usage
 
 ### `rollup.config.js`
 
 ```js
+const replace = require('@rollup/plugin-replace');
 const workbox = require('rollup-plugin-workbox-inject');
 
 module.exports = {
   input: /*...*/,
   output: /*...*/,
   plugins: [
+    // @rollup/plugin-replace is used to replace process.env.NODE_ENV
+    // statements in the Workbox libraries to match your current environment.
+    // This changes whether logging is enabled ('development') or disabled ('production').
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
+    }),
     workbox({
-      swSrc: 'src/sw.js',
-      swDest: 'public/sw.js',
       globDirectory: 'public',
       globPatterns: [
         'css/**/*.css',
         'js/**/*.js'
-      ]
-    })
+      ],
+      // ...any other options here...
+    }),
   ]
 }
 ```
 
-- `swSrc` - The source file of the service worker. Workbox uses it to ensure it's not accidentally cached. You need to configure Rollup separately to compile this file.
-- `swDest` - The destination file of the service worker. Workbox uses it to ensure it's not accidentally cached. You need to configure Rollup separately to output this file.
-- `globDirectory` - The directory that the files being globbed exist in
-- `globPatterns` - The patterns to glob and inject for precaching
+The options
+[supported by the `getManifest()` method in `workbox-build`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.getManifest)
+are supported in this plugin, with one addition:
+
+- `injectionPoint`: Defaults to `'self.__WB_MANIFEST'`, but can be changed if
+  you'd like to customize which string is replaced with the precache manifest in
+  your source service worker file.
 
 ### Service Worker
 
-**Requires Workbox v5.0.0-rc.1 or greater!**
+**Requires using Workbox v5+ in your service worker file!**
 
 ```js
 import { precacheAndRoute } from 'workbox-precaching';
 
 precacheAndRoute(self.__WB_MANIFEST);
+
+// ...any other service worker logic goes here...
 ```

--- a/modules/rollup-plugin-workbox-inject/index.js
+++ b/modules/rollup-plugin-workbox-inject/index.js
@@ -15,15 +15,15 @@
  */
 
 const chalk = require('chalk');
-const defaults = require('workbox-build/src/options/defaults');
-const getFileManifestEntries = require('workbox-build/src/lib/get-file-manifest-entries');
-const getManifestSchema = require('workbox-build/src/options/schema/get-manifest');
+const defaults = require('workbox-build/build/options/defaults');
+const getFileManifestEntries = require('workbox-build/build/lib/get-file-manifest-entries');
+const getManifestSchema = require('workbox-build/build/options/schema/get-manifest');
 const prettyBytes = require('pretty-bytes');
-const rebasePath = require('workbox-build/src/lib/rebase-path');
-const replaceAndUpdateSourceMap = require('workbox-build/src/lib/replace-and-update-source-map');
+const rebasePath = require('workbox-build/build/lib/rebase-path');
+const replaceAndUpdateSourceMap = require('workbox-build/build/lib/replace-and-update-source-map');
 const stringify = require('fast-json-stable-stringify');
 const upath = require('upath');
-const validate = require('workbox-build/src/lib/validate-options');
+const validate = require('workbox-build/build/lib/validate-options');
 
 /**
  * Rollup plugin to inject Workbox precaching information in-line

--- a/modules/rollup-plugin-workbox-inject/package.json
+++ b/modules/rollup-plugin-workbox-inject/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rollup-plugin-workbox-inject",
   "version": "1.0.1",
-  "description": "Inject workbox precaching into a Rollup compiled service worker",
+  "description": "Injects a Workbox precache manifest into a Rollup-compiled service worker.",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
@@ -9,7 +9,8 @@
     "test:lerna": "lerna run --scope \"${PWD##*/}\" test"
   },
   "keywords": [
-    "rollup-plugin"
+    "rollup-plugin",
+    "workbox"
   ],
   "contributors": [
     "Sam Richard <snugug@google.com> (https://snugug.com)"
@@ -20,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "workbox-build": "^5.0.0"
+    "rollup": "^1.2.0"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Updates to the README, some `package.json` fields, and the location from which the `workbox-build` sub-modules are imported.