### PR TITLE
remove step from condition

### DIFF
--- a/modules/eleventy-plugin-local-respimg/lib/respimg.js
+++ b/modules/eleventy-plugin-local-respimg/lib/respimg.js
@@ -131,7 +131,7 @@ function respimgSetup(userConfig = {}) {
               const genMax = max < size.width ? max : size.width;
               const sizes = [];
 
-              if (min + step <= size.width) {
+              if (min <= size.width) {
                 for (let i = min; i < genMax; i += step) {
                   sizes.push(i);
                 }


### PR DESCRIPTION
This I thought was appropriate as `i = min` is also intended to run in the `for` loop. Eg. If `min=250` with `step = 150` and `img.width=300`, width of 250 would not be created.