### PR TITLE
🐛 (eleventy-plugin-local-respimg) Pick <img> for transforming correctly

### DIFF
--- a/modules/eleventy-plugin-local-respimg/lib/respimg.js
+++ b/modules/eleventy-plugin-local-respimg/lib/respimg.js
@@ -95,7 +95,7 @@ function respimgSetup(userConfig = {}) {
     if (outputPath && outputPath.endsWith('.html')) {
       const $ = cheerio.load(content);
 
-      const images = $(':not(picture) img').get();
+      const images = $('img').not('picture img').get();
       // const pictures = $('picture img, picture source');
 
       // Optimize and make responsive images not already in an image tag


### PR DESCRIPTION
The <img>s wrapped with <picture> elements are skipped.

Closes #29