### PR TITLE
Add AVIF image output support

### DIFF
--- a/modules/eleventy-plugin-local-respimg/lib/resize.js
+++ b/modules/eleventy-plugin-local-respimg/lib/resize.js
@@ -70,13 +70,15 @@ async function resizeAndOptimize(sizes, type, src, buff, config) {
         }
 
         const webp = await generateWebp(output, config);
-
+				const avif = await generateAvif(output, config);
         const outputDest = outputURL(src, size, type.ext, config.folders.output);
         const webpDest = outputURL(src, size, 'webp', config.folders.output);
+	      const avifDest = outputURL(src, size, 'avif', config.folders.output);
 
         return [
           { dest: outputDest, buff: output },
           { dest: webpDest, buff: webp },
+	        { dest: avifDest, buff: avif },
         ];
       });
     }
@@ -146,6 +148,19 @@ function generateWebp(buff, config) {
   return imagemin.buffer(buff, {
     plugins: [imageminWebP(config.images.webp || {}), gif2webp(config.images.gifwebp || {})],
   });
+}
+
+/**
+ *
+ * @param {buffer} buff - Input buffer
+ * @param {object} config - Config
+ *
+ * @return {buffer}
+ */
+function generateAvif(buff, config) {
+	return sharp(buff)
+		.heif(config.images.avif)
+		.toBuffer();
 }
 
 /**

--- a/modules/eleventy-plugin-local-respimg/lib/respimg.js
+++ b/modules/eleventy-plugin-local-respimg/lib/respimg.js
@@ -39,6 +39,9 @@ const baseConfig = {
       max: 1500,
       step: 150,
     },
+	  avif: {
+    	compression: 'av1',
+	  },
     gifToVideo: false,
     sizes: '100vw',
     lazy: true,
@@ -95,9 +98,7 @@ function respimgSetup(userConfig = {}) {
     if (outputPath && outputPath.endsWith('.html')) {
       const $ = cheerio.load(content);
 
-      const images = $('img')
-        .not('picture img')
-        .get();
+      const images = $(':not(picture) img').get();
       // const pictures = $('picture img, picture source');
 
       // Optimize and make responsive images not already in an image tag
@@ -109,9 +110,6 @@ function respimgSetup(userConfig = {}) {
           if (local) {
             const respSizes = $(image).attr('sizes') || config.images.sizes;
             $(image).removeAttr('sizes');
-
-            const respLoading = $(image).attr('loading') || (config.images.lazy && 'lazy');
-            $(image).removeAttr('loading');
 
             const file = readFileSync(path.join(config.folders.source, src));
             ensureDirSync(path.join(config.folders.output, path.dirname(src)));
@@ -149,8 +147,8 @@ function respimgSetup(userConfig = {}) {
               const width = genMax;
               $(image).attr('height', height);
               $(image).attr('width', width);
-              if (respLoading) {
-                $(image).attr('loading', respLoading);
+              if (config.images.lazy) {
+                $(image).attr('loading', 'lazy');
               }
 
               let optimize = true;
@@ -170,9 +168,11 @@ function respimgSetup(userConfig = {}) {
               if (imagemap[src].length > 1) {
                 const baseSrcset = generateSrcset(sizes, src, type.ext);
                 const webpSrcset = generateSrcset(sizes, src, 'webp');
+	              const avifSrcset = generateSrcset(sizes, src, 'avif');
 
                 const imgHTML = $.html(image);
                 let img = `<picture>`;
+	              img += `<source srcset="${avifSrcset}" sizes="${respSizes}" type="image/avif">`;
                 img += `<source srcset="${webpSrcset}" sizes="${respSizes}" type="image/webp">`;
                 img += `<source srcset="${baseSrcset}" sizes="${respSizes}" type="${type.mime}">`;
                 img += `${imgHTML}</picture>`;

--- a/modules/eleventy-plugin-local-respimg/package.json
+++ b/modules/eleventy-plugin-local-respimg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-local-respimg",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "Eleventy plugin for optimizing and making responsive local images",
   "keywords": [
     "eleventy",
@@ -32,21 +32,21 @@
   "homepage": "https://github.com/chromeos/static-site-scaffold-modules#readme",
   "license": "Apache-2.0",
   "dependencies": {
-    "@gumlet/gif-resize": "^1.1.1",
+    "@gumlet/gif-resize": "^1.0.4",
     "cheerio": "^1.0.0-rc.3",
-    "fast-glob": "^3.2.4",
-    "file-type": "^14.6.2",
-    "fs-extra": "^9.0.1",
+    "fast-glob": "^3.1.1",
+    "file-type": "^13.0.3",
+    "fs-extra": "^8.1.0",
     "image-size": "^0.8.3",
     "imagemin": "^7.0.1",
-    "imagemin-gif2webp": "^3.0.0",
-    "imagemin-mozjpeg": "^9.0.0",
-    "imagemin-pngquant": "^9.0.0",
-    "imagemin-svgo": "^8.0.0",
-    "imagemin-webp": "^6.0.0",
+    "imagemin-gif2webp": "^2.0.0",
+    "imagemin-mozjpeg": "^8.0.0",
+    "imagemin-pngquant": "^8.0.0",
+    "imagemin-svgo": "^7.0.0",
+    "imagemin-webp": "^5.1.0",
     "merge-deep": "^3.0.2",
-    "replace-ext": "^2.0.0",
-    "sharp": "^0.25.4"
+    "replace-ext": "^1.0.0",
+    "sharp": "^0.25.2"
   },
   "devDependencies": {
     "fluent-ffmpeg": "^2.1.2",


### PR DESCRIPTION
Making this PR in anticipation of libheif/libvips adding the AV1 encoder to their mainstream binaries, it currently requires a custom built version of libvips to get working, also requires you override the compression method with 'av1' because the default is 'hevc' so browsers wont decode it. 

TODO: Add new tags containing AVIF links to tests. 