### PR TITLE
fix: Crashes on Node.js v16.8.0

### DIFF
--- a/modules/vite-plugin-posthtml/index.js
+++ b/modules/vite-plugin-posthtml/index.js
@@ -29,7 +29,7 @@ const posthtmlPlugin = (opts = {}) => {
 
     performance.clearMarks();
   });
-  observer.observe({ entryTypes: ['measure'], type: 'measure' });
+  observer.observe({ entryTypes: ['measure'] });
 
   return {
     name: 'posthtml',


### PR DESCRIPTION
## This is a fatal bug !

I'm doing a build in github action and the problem occurs in both node version 16.6.2 and node version 14.18.2.

The strange thing is that when I buiid the same above node version on local windows there is no problem.

But for now, it is clear that this problem is generated by the following code👇:

https://github.com/chromeos/static-site-scaffold-modules/blob/fc4565852b6463998590b13ae45d03a93951e267/modules/vite-plugin-posthtml/index.js#L32

Can be obtained from document [PerformanceObserver.observe()](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe).

![image](https://user-images.githubusercontent.com/44798353/148686855-13e60f1d-ffd0-4757-9c66-e47da061c444.png)

fix: #85 
